### PR TITLE
Fixed Typo in user/bulk route of user router

### DIFF
--- a/Backend/index.js
+++ b/Backend/index.js
@@ -3,9 +3,7 @@ const cors = require("cors");
 const mainRouter = require("./routes/index");
 const app=express();
 
-app.use(cors({
-    origin:"http://localhost:5173"
-}));
+app.use(cors());
 app.use(express.json());
 
 app.use("/api/v1",mainRouter);

--- a/Backend/routes/user.js
+++ b/Backend/routes/user.js
@@ -128,7 +128,7 @@ router.get("/bulk", async (req,res) => {
             username: user.username,
             firstName: user.firstName,
             lastName: user.lastName,
-            _id: user.user_id
+            _id: user._id
 
         }))
     })


### PR DESCRIPTION
There was a typo int /bulk api of user route which was not sending user ID in json body and in transfer endpoint it's sending id as undefined which was crashing the backend application. Hence error in network request from browser.
![image](https://github.com/user-attachments/assets/3887b0f1-2bdb-45c5-ac90-cf44b27772ae)
